### PR TITLE
Gpicview is not playing animated GIFs

### DIFF
--- a/src/image-view.c
+++ b/src/image-view.c
@@ -341,15 +341,12 @@ void image_view_clear( ImageView* iv )
 
 void image_view_set_pixbuf( ImageView* iv, GdkPixbuf* pixbuf )
 {
-    if( pixbuf != iv->pix )
-    {
-        image_view_clear( iv );
-        if( G_LIKELY(pixbuf) )
-            iv->pix = (GdkPixbuf*)g_object_ref( pixbuf );
-        calc_image_area( iv );
-        gtk_widget_queue_resize( (GtkWidget*)iv );
-//        gtk_widget_queue_draw( (GtkWidget*)iv);
-    }
+    image_view_clear( iv );
+    if( G_LIKELY(pixbuf) )
+        iv->pix = (GdkPixbuf*)g_object_ref( pixbuf );
+    calc_image_area( iv );
+    gtk_widget_queue_resize( (GtkWidget*)iv );
+//    gtk_widget_queue_draw( (GtkWidget*)iv);
 }
 
 void image_view_set_scale( ImageView* iv, gdouble new_scale, GdkInterpType type )


### PR DESCRIPTION
When attempting to open a GIF image using Gpicview, the image remains static and does not animate as expected. This appears to be an old issue that persists in the latest versions. With each update, this adjustment has to be done manually.

This pull request proposes a fix for this issue to prevent the need for manual adjustments in the future.