### PR TITLE
Prevent Wayland crash in working-area X11 code path

### DIFF
--- a/src/working-area.c
+++ b/src/working-area.c
@@ -23,14 +23,20 @@
 */
 
 # include <gdk/gdk.h>
+
+#ifdef GDK_WINDOWING_X11
 # include <gdk/gdkx.h>
 # include <X11/Xlib.h>
 # include <X11/Xutil.h>
 # include <X11/Xatom.h>
+#endif
 
 void get_working_area(GdkScreen* screen, GdkRectangle *rect);
 
 static gboolean gf_display_get_workarea(GdkScreen* g_screen, GdkRectangle *rect) {
+#ifndef GDK_WINDOWING_X11
+	return FALSE;
+#else
 	Atom xa_desktops, xa_current, xa_workarea, xa_type;
 	Display *x_display;
 	Window x_root;
@@ -45,6 +51,9 @@ static gboolean gf_display_get_workarea(GdkScreen* g_screen, GdkRectangle *rect)
 	/* get the gdk display */
 	g_display = gdk_display_get_default();
 	if(!g_display)
+		return FALSE;
+
+	if(!GDK_IS_X11_DISPLAY(g_display) || !GDK_IS_X11_SCREEN(g_screen))
 		return FALSE;
 
 	/* get the x display from the gdk display */
@@ -134,6 +143,7 @@ static gboolean gf_display_get_workarea(GdkScreen* g_screen, GdkRectangle *rect)
 	XFree(data);
 
 	return TRUE;
+#endif
 }
 
 void get_working_area(GdkScreen* screen, GdkRectangle *rect)

--- a/src/working-area.c
+++ b/src/working-area.c
@@ -53,8 +53,10 @@ static gboolean gf_display_get_workarea(GdkScreen* g_screen, GdkRectangle *rect)
 	if(!g_display)
 		return FALSE;
 
+#if defined(GDK_IS_X11_DISPLAY) && defined(GDK_IS_X11_SCREEN)
 	if(!GDK_IS_X11_DISPLAY(g_display) || !GDK_IS_X11_SCREEN(g_screen))
 		return FALSE;
+#endif
 
 	/* get the x display from the gdk display */
 	x_display = gdk_x11_display_get_xdisplay(g_display);


### PR DESCRIPTION
This PR fixes a crash when `gpicview` is run on non-X11 backends, notably native Wayland sessions.  This is currently an issue on Gnome desktop in Debian Testing.

## Cause

`gpicview` uses `src/working-area.c` to query the desktop work area when choosing its initial window size and zoom mode.  That code assumes the active GDK backend is X11 and unconditionally calls `gdk_x11_display_get_xdisplay()` / `gdk_x11_screen_get_xscreen()`. On Wayland, those assumptions are invalid, which can lead to a crash when opening an image.

## Fix

The fix is deliberately small: it keeps the existing X11 code path unchanged, but only uses it when the current display/screen are actually X11. On non-X11 backends, it returns the existing fallback path instead, which uses the screen dimensions.

- This solution preserves current behavior on X11.
- This solution avoids backend-specific calls on Wayland and other non-X11 backends.
- It reuses the fallback behavior the file already had, rather than introducing new platform-specific logic.